### PR TITLE
Setup dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
この example は、常に最新の状態に保ちたいと考えています。

そこで、GitHub Dependabot を使って依存ライブラリの検知と更新PRの作成を自動化します。
https://docs.github.com/ja/github/administering-a-repository/enabling-and-disabling-version-updates

方針は次の通りです。

- Dependabot の仕事 (これを実現する)
  - `Gemfile` で直接指定しているライブラリが対象
  - 毎日チェック
  - 新しいバージョンがリリースされたら、更新するPRを作成
- 人間の仕事
  - PRをレビューしてマージ (ちゃんとテストを書いてあるので、基本的には CI がパスすればマージして良いと思う)

各設定は下記ドキュメントを参照してください。
https://docs.github.com/ja/github/administering-a-repository/configuration-options-for-dependency-updates