### PR TITLE
Run CI build only on either pull request or push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
   test:
     name: Test with Ruby ${{ matrix.ruby_version }}
     runs-on: ubuntu-latest
+    # Run this build only on either pull request or push.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       matrix:
         ruby_version:


### PR DESCRIPTION
現状、このリポジトリで pull request を作ると、CI workflow が重複して実行されてしまいます。

原因は単純で、下記のように、 push と pull_request でトリガーされるからです。
https://github.com/thinreports/thinreports-rails-example/blob/1722f431df934f3c5138f2a64cf43e08d1c2b9a4/.github/workflows/ci.yml#L3-L5

これを解決するために、ベースリポジトリがこのリポジトリの場合は pull_request トリガーでのビルドを抑制します。

下記の通り、pull_request トリガーが skip されるようになります。

![image](https://user-images.githubusercontent.com/739339/106379860-3a859300-63f2-11eb-9fe7-49530c0bee8e.png)

ベストな解決方法ではないですが、とりあえずこれで。